### PR TITLE
Add power state, user manual, message structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ A simple service to toggle power state of a device.
 
 ## Usage
 
+Service is shipped as APT package, see [release](https://github.com/starwit/power-toggle-service/releases) page to download latest package. How to configure and use service see [manual](doc/MANUAL.md).
+
 ## Build
+
+Here are all necessarey information for developers, to build and run service.
 
 ### Prerequisites
 Things you need to build package.
@@ -22,6 +26,9 @@ make build-deb
 APT package can then be found in folder _target_. You can test installation using Docker, however SystemD (probably) won't work.
 ```bash
 docker run -it --rm -v ./target:/app  jrei/systemd-ubuntu:latest bash
-apt update && apt install -y /app/power-toggle-switch_0.0.1_all.deb
+apt update && apt install -y /app/power-toggle-switch_0.0.7_all.deb
 ```
-You can however test, if everyting is installed to the right place.
+You can however test, if everything is installed to the right place. If you want to test service use the following command to trigger power off:
+```bash
+echo -n '{"state": "shutdown"}' | nc -4u -q1 vm.ip.address 5151
+```

--- a/debian/power-toggle-switch.service
+++ b/debian/power-toggle-switch.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+User=powertoggle
 WorkingDirectory=/opt/power-toggle-switch
 ExecStart=/usr/local/bin/power-toggle-switch
 Restart=always

--- a/debian/preinst
+++ b/debian/preinst
@@ -2,3 +2,14 @@
 
 mkdir -p /etc/power-toggle-switch
 mkdir -p /opt/power-toggle-switch
+
+useradd -M powertoggle
+usermod -L powertoggle
+
+mkdir -p /etc/sudoers.d
+
+cat <<EOF >/etc/sudoers.d/power-toggle-switch
+powertoggle ALL=(ALL) NOPASSWD: /sbin/shutdown, /sbin/reboot, /sbin/poweroff
+EOF
+
+chmod 440 /etc/sudoers.d/power-toggle-switch

--- a/debian/prerm
+++ b/debian/prerm
@@ -24,6 +24,12 @@ if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
 
     # Remove config files directory
     rm -rf /etc/$SERVICE_NAME
+
+    # remove user
+    userdel powertoggle
+
+    # remove visudo file
+    rm -f /etc/sudoers.d/$SERVICE_NAME
 fi
 
 #DEBHELPER#

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1,0 +1,29 @@
+# Power Toggle Service User's Manual
+In this document, you'll find all information to run and to use Power Toggle Service.
+
+## Configuration
+
+After installation config file of service is located at /etc/power-toggle-switch/settings.yaml. Here is an example of configuration file:
+
+```yaml
+log_level: INFO
+bind_address: 0.0.0.0 # bind address for service
+udp_port: 5151 # port for listener
+shutdown_timeout: 180 # shutdown delay in seconds
+```
+
+To see if service is running use the following command:
+```bash
+systemctl status power-toggle-service
+```
+
+Please refer to SystemD documentation for more info, on how to use services, e.g. https://wiki.archlinux.org/title/Systemd
+
+## Network Messages
+Following example shows, how a shutdown message is supposed to look like:
+
+```json
+{
+    "state": "shutdown"
+}
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -243,14 +243,14 @@ anchors = ["unidecode"]
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2"},
-    {file = "pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"},
+    {file = "pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a"},
+    {file = "pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423"},
 ]
 
 [package.dependencies]
@@ -826,4 +826,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "16ff55170fc3a38e79458e5c64a5560fc52f93cc064cea96a3798dcfe271d3c8"
+content-hash = "7064be10913d81e3148e02e2cb48af9e0e6a7a95b4626cf09cc3df105b86ac7c"

--- a/power_toggle_switch/power_state.py
+++ b/power_toggle_switch/power_state.py
@@ -1,0 +1,35 @@
+from enum import Enum
+import json
+from power_toggle_switch.config import PowerToggleConfig
+import logging
+
+class State(str, Enum):
+    NORMAL = 'NORMAL'
+    SHUTDOWN = 'SHUTDOWN'
+
+
+class PowerState():
+    def __init__(self, config: PowerToggleConfig, logger: logging.Logger):
+        self.config = config
+        self.state: State = State.NORMAL
+        self.logger = logger
+    
+    def set_state(self, state: State):
+        self.state = state
+        
+    def get_state(self) -> State:
+        return self.state
+    
+    def process_message(self, message: str) -> State:
+        try:
+            data = json.loads(message)
+            state_value = data.get('state', '').lower()
+            
+            if state_value == 'shutdown':
+                self.set_state(State.SHUTDOWN)
+            elif state_value == 'normal':
+                self.set_state(State.NORMAL)
+        except (json.JSONDecodeError, KeyError):
+            self.logger.error("Invalid message format or missing 'state' key " + message)
+        
+        return self.get_state()

--- a/power_toggle_switch/power_toggle_switch.py
+++ b/power_toggle_switch/power_toggle_switch.py
@@ -1,13 +1,19 @@
 import logging
-import time
 import signal
-import threading
-from power_toggle_switch.config import PowerToggleConfig
 import socket
+import threading
+import subprocess
+from power_toggle_switch.config import PowerToggleConfig
+from power_toggle_switch.power_state import PowerState, State
 
 logger = logging.getLogger(__name__)
 
 def run_stage():
+    CONFIG = PowerToggleConfig()
+    logging.basicConfig(level=CONFIG.log_level.value, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger.setLevel(CONFIG.log_level.value)
+    
+    power_state = PowerState(CONFIG, logger)
 
     stop_event = threading.Event()
 
@@ -15,14 +21,11 @@ def run_stage():
     def sig_handler(signum, _):
         signame = signal.Signals(signum).name
         print(f'Caught signal {signame} ({signum}). Exiting...')
+        power_state.set_state(State.NORMAL)
         stop_event.set()
 
     signal.signal(signal.SIGTERM, sig_handler)
     signal.signal(signal.SIGINT, sig_handler)
-
-    CONFIG = PowerToggleConfig()
-    logging.basicConfig(level=CONFIG.log_level.value, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    logger.setLevel(CONFIG.log_level.value)
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind((CONFIG.bind_address, CONFIG.udp_port))
@@ -32,8 +35,20 @@ def run_stage():
         while not stop_event.is_set():
             try:
                 data, addr = sock.recvfrom(1024)
-                print(f"Received packet from {addr}: {data.decode('utf-8')}")
+                logger.debug(f"Received message: {data.decode('utf-8')} from {addr}")
+                power_state.process_message(data.decode('utf-8'))
+                if power_state.get_state() == State.SHUTDOWN:
+                    logger.info("Shutting down in %s seconds", CONFIG.shutdown_delay)
+                    threading.Timer(CONFIG.shutdown_delay, lambda: stop_event.set()).start()
             except socket.timeout:
                 continue  # Check stop_event again
+        shutdown_server(power_state)
     finally:
         sock.close()
+        
+def shutdown_server(power_state):
+    if power_state.get_state() == State.NORMAL:
+        logger.info("Stop service without powering off server")
+    if power_state.get_state() == State.SHUTDOWN:
+        logger.info("Powering off server")
+        subprocess.run(["sudo", "shutdown", "-h", "+1"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pydantic = "^2.11.9"
+pydantic = "^2.11.10"
 pydantic-settings = "^2.0.3"
 pyaml = "^25.7.0"
 pytest = "8.4.2"


### PR DESCRIPTION
Service has now a power state, that is set via UDP messages.

## Motivation and Context
Having a global power state, allows better control. Shutting down service via systemctl does not power off Linux.

## How has this been tested?
Docker install / VM

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
